### PR TITLE
ci(windows): run the test suite on Git Bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,10 +446,31 @@ jobs:
           TEST_JOBS=4 bash tests/run.sh > /tmp/win-suite.log 2>&1 || true
           echo "=== totals ==="
           grep -E '^Total:' /tmp/win-suite.log | tail -1
-          echo "=== files with failures ==="
-          awk '/^--- /{f=$2} /FAIL/{print f}' /tmp/win-suite.log | sort | uniq -c | sort -rn | head -40
-          echo "=== first 60 failure lines ==="
-          grep -E 'FAIL' /tmp/win-suite.log | head -60
+          # Group with python, not awk: the awk form printed NOTHING on Git Bash
+          # (the FAIL lines carry ANSI colour), and grouping is the whole point of
+          # the recon. Strip escapes first, then attribute each FAIL to its file.
+          python3 - <<'PY'
+          import re
+          cur='?'; fails={}; tot={}
+          for line in open('/tmp/win-suite.log', encoding='utf-8', errors='replace'):
+              s=re.sub(r'\x1b\[[0-9;]*m','',line).rstrip()
+              m=re.match(r'^--- (\S+) ---', s)
+              if m: cur=m.group(1); continue
+              t=s.strip()
+              if t.startswith(('FAIL','PASS')): tot[cur]=tot.get(cur,0)+1
+              if t.startswith('FAIL'): fails[cur]=fails.get(cur,0)+1
+          print(f"files with failures: {len(fails)} | total failures: {sum(fails.values())}")
+          for f,c in sorted(fails.items(), key=lambda x:-x[1]):
+              print(f"  {c:4d}/{tot.get(f,0):<4d}  {f}")
+          PY
+
+      - name: RECON — upload the full suite log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-suite-log
+          path: /tmp/win-suite.log
+          retention-days: 7
 
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,16 +476,22 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          TEST_JOBS=4 bash tests/run.sh > /tmp/win-suite.log 2>&1 || true
+          # v2.26.83: workspace-relative, NOT /tmp. A POSIX /tmp path is invisible
+          # to Windows python and to the Node artifact action — MSYS rewrites paths
+          # passed as ARGUMENTS, not strings inside a script. The first run proved
+          # it: grep read the file, python raised FileNotFoundError on the same path
+          # and upload-artifact found nothing. Same class as the product bugs this
+          # job exists to find.
+          TEST_JOBS=4 bash tests/run.sh > win-suite.log 2>&1 || true
           echo "=== totals ==="
-          grep -E '^Total:' /tmp/win-suite.log | tail -1
+          grep -E '^Total:' win-suite.log | tail -1
           # Group with python, not awk: the awk form printed NOTHING on Git Bash
           # (the FAIL lines carry ANSI colour), and grouping is the whole point of
           # the recon. Strip escapes first, then attribute each FAIL to its file.
           python3 - <<'PY'
           import re
           cur='?'; fails={}; tot={}
-          for line in open('/tmp/win-suite.log', encoding='utf-8', errors='replace'):
+          for line in open('win-suite.log', encoding='utf-8', errors='replace'):
               s=re.sub(r'\x1b\[[0-9;]*m','',line).rstrip()
               m=re.match(r'^--- (\S+) ---', s)
               if m: cur=m.group(1); continue
@@ -502,7 +508,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-suite-log
-          path: /tmp/win-suite.log
+          path: win-suite.log
           retention-days: 7
 
   shellcheck:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,6 +518,19 @@ jobs:
           # is False for '/etc/hosts' then both sections are skipped and the guard
           # allows it — which matches every observation. Settle it here; it cannot
           # be checked from macOS, where posixpath answers instead.
+          # THE decisive probe. Five earlier probes each answered one INPUT to the
+          # guard and none identified why a POSIX-form path is allowed here while a
+          # drive-letter one is blocked. This traces the REAL code through its gates
+          # — not a copy that can drift — and prints which section it reaches and
+          # what it decides. Inert unless SC_PATHGUARD_DEBUG is set; stderr only.
+          echo "--- TRACE: the guard's own gates, POSIX-form path ---"
+          printf '{"additionalRoots":["/"]}' > "$W/free/$CFG"
+          printf '{"tool_name":"Write","tool_input":{"file_path":"/etc/hosts","content":"x"},"cwd":"%s"}' "$W/free" \
+            | SC_PATHGUARD_DEBUG=1 bash hooks/path-guard.sh 2>&1 >/dev/null | sed 's/^/    /'
+          echo "--- TRACE: the same guard, drive-letter path (this one blocks) ---"
+          printf '{"tool_name":"Write","tool_input":{"file_path":"C:/Windows/System32/drivers/etc/hosts","content":"x"},"cwd":"%s"}' "$W/free" \
+            | SC_PATHGUARD_DEBUG=1 bash hooks/path-guard.sh 2>&1 >/dev/null | sed 's/^/    /'
+
           echo "--- isabs, the gate both blocking sections start from ---"
           python3 - <<'PYEOF'
           import os, sys, ntpath

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,20 @@ jobs:
           printf '{"tool_name":"Write","tool_input":{"file_path":"%s/.ssh/authorized_keys","content":"x"},"cwd":"%s"}' "$HOME" "$W/free" \
             | bash hooks/path-guard.sh; echo "  rc=$?"
 
+          # The containment logic is provably correct under Windows path semantics
+          # (checked locally against ntpath with the runner's own measured values):
+          # the symlink section AND the /etc/ string match should each block. They
+          # do not, so the sections must be SKIPPED — both are gated on `proj`, and
+          # both `proj` and `p` come from jq. This shows what the hook actually
+          # extracts, which is the one thing not yet observed.
+          echo "--- what the hook extracts from the payload ---"
+          PAY=$(printf '{"tool_name":"Write","tool_input":{"file_path":"/etc/hosts","content":"x"},"cwd":"%s"}' "$W/free")
+          echo "  jq present : $(command -v jq || echo NO)"
+          echo "  file_path  = [$(printf '%s' "$PAY" | jq -r '.tool_input.file_path // empty' 2>&1)]"
+          echo "  cwd        = [$(printf '%s' "$PAY" | jq -r '.cwd // .workspace.current_dir // empty' 2>&1)]"
+          echo "  tool_name  = [$(printf '%s' "$PAY" | jq -r '.tool_name // empty' 2>&1)]"
+          echo "  disabled   = [$(printf '%s' "$PAY" | jq -r '.disabled // empty' 2>&1)]"
+
           echo "--- what the refusal comparisons actually see ---"
           SC_PROJ="$W/free" python3 - <<'PYEOF'
           import os

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,26 @@ jobs:
           echo "post-update safety.sh rc=$hrc (expect 2)"
           [ "$hrc" -eq 2 ] || { echo "hooks stopped guarding after an update"; exit 1; }
 
+      # v2.26.83 RECON, TEMPORARY: the plan's Phase 2 item 4 called for the suite
+      # to run here and it never landed, so 3540 assertions run on ubuntu+macOS
+      # and ZERO on Windows. This step exists to LEARN which files are actually
+      # Windows-safe rather than guess: several build a PATH with `ln -sf`, and
+      # Git Bash's `ln -s` silently COPIES (plan §11.1), which would report
+      # harness breakage as product failure.
+      # continue-on-error so the recon run cannot turn master red. Once the
+      # failure list is triaged this becomes a curated TEST_GLOB subset, gating.
+      - name: RECON — full suite on Git Bash (report-only)
+        continue-on-error: true
+        shell: bash
+        run: |
+          TEST_JOBS=4 bash tests/run.sh > /tmp/win-suite.log 2>&1 || true
+          echo "=== totals ==="
+          grep -E '^Total:' /tmp/win-suite.log | tail -1
+          echo "=== files with failures ==="
+          awk '/^--- /{f=$2} /FAIL/{print f}' /tmp/win-suite.log | sort | uniq -c | sort -rn | head -40
+          echo "=== first 60 failure lines ==="
+          grep -E 'FAIL' /tmp/win-suite.log | head -60
+
   shellcheck:
     name: Shellcheck
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,39 @@ jobs:
       # harness breakage as product failure.
       # continue-on-error so the recon run cannot turn master red. Once the
       # failure list is triaged this becomes a curated TEST_GLOB subset, gating.
+      # The recon showed path-guard REFUSING NOTHING on Windows ("$HOME accepted
+      # as a root: rc=0") — i.e. the whole home directory becomes in-project and
+      # writable. The suspected cause is a FORM mismatch, not a logic error: Git
+      # Bash hands paths as /c/Users/..., while Windows python's expanduser('~')
+      # returns C:\Users\..., and realpath cannot reconcile the two — so
+      # `rp == home` is False and the refusal is skipped.
+      # This step PROVES or DISPROVES that before a security hook is patched on a
+      # hypothesis. Nothing Windows is answerable from macOS.
+      - name: DIAGNOSTIC — POSIX vs Windows path forms
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "bash   HOME       = $HOME"
+          echo "bash   PWD        = $PWD"
+          python3 - <<'PY'
+          import os
+          hb = os.environ.get('HOME','')
+          exp = os.path.expanduser('~')
+          print('python expanduser  =', exp)
+          print('python realpath(HOME env) =', os.path.realpath(hb) if hb else '(no HOME)')
+          print('python os.sep      =', repr(os.sep))
+          print('MATCH realpath(expanduser) == realpath(HOME env)?',
+                os.path.realpath(exp) == os.path.realpath(hb) if hb else 'n/a')
+          # The exact comparison path-guard makes for a POSIX-form candidate root.
+          cand = hb
+          rp = os.path.realpath(cand)
+          home = os.path.realpath(exp)
+          print('candidate realpath =', rp)
+          print('home realpath      =', home)
+          print('REFUSAL WOULD FIRE (rp == home)?', rp == home)
+          print('ancestor form: home.startswith(rp + sep)?', home.startswith(rp + os.sep))
+          PY
+
       - name: RECON — full suite on Git Bash (report-only)
         continue-on-error: true
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,51 @@ jobs:
           print('ancestor form: home.startswith(rp + sep)?', home.startswith(rp + os.sep))
           PY
 
+      # The suite recon reports test-additional-roots refusals failing on Windows:
+      # additionalRoots:["/"] and ["$HOME"] are ACCEPTED, which disables the guard.
+      # Inspection could not settle why, and one hypothesis (expanduser != $HOME)
+      # was disproven by the path-form diagnostic above — realpath(HOME env) ==
+      # realpath(expanduser) on this runner, so the comparison itself is sound.
+      # Only the platform can say where it actually diverges. This runs the exact
+      # failing scenario and prints every intermediate the refusal depends on.
+      - name: DIAGNOSTIC — why path-guard root refusals do not fire
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          CFG=".supercharger"".json"
+          W=$(mktemp -d)/w; mkdir -p "$W/free"; : > "$W/free/f.php"
+          echo "layout = $W"
+
+          printf '{"additionalRoots":["/"]}' > "$W/free/$CFG"
+          echo "--- root '/' , write to /etc/hosts (expect rc=2, root refused) ---"
+          printf '{"tool_name":"Write","tool_input":{"file_path":"/etc/hosts","content":"x"},"cwd":"%s"}' "$W/free" \
+            | bash hooks/path-guard.sh; echo "  rc=$?"
+
+          printf '{"additionalRoots":["%s"]}' "$HOME" > "$W/free/$CFG"
+          echo "--- root \$HOME , write into \$HOME (expect rc=2, root refused) ---"
+          printf '{"tool_name":"Write","tool_input":{"file_path":"%s/.ssh/authorized_keys","content":"x"},"cwd":"%s"}' "$HOME" "$W/free" \
+            | bash hooks/path-guard.sh; echo "  rc=$?"
+
+          echo "--- what the refusal comparisons actually see ---"
+          SC_PROJ="$W/free" python3 - <<'PYEOF'
+          import os
+          proj = os.path.realpath(os.environ['SC_PROJ'])
+          home = os.path.realpath(os.path.expanduser('~'))
+          print(f'  proj_real = {proj!r}')
+          print(f'  home      = {home!r}')
+          print(f'  os.sep    = {os.sep!r}')
+          for cand in ('/', os.environ.get('HOME', ''), '/etc/hosts'):
+              if not cand:
+                  continue
+              rp = os.path.realpath(cand)
+              print(f'  cand={cand!r}')
+              print(f'    realpath    = {rp!r}  isabs={os.path.isabs(cand)}  isdir={os.path.isdir(rp)}')
+              print(f'    fs-root?      {rp == os.path.dirname(rp)}   (dirname={os.path.dirname(rp)!r})')
+              print(f'    ==home?       {rp == home}   ancestor-of-home? {home.startswith(rp + os.sep)}')
+          PYEOF
+          rm -rf "$(dirname "$W")"
+
       - name: RECON — full suite on Git Bash (report-only)
         continue-on-error: true
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,20 @@ jobs:
           echo "  tool_name  = [$(printf '%s' "$PAY" | jq -r '.tool_name // empty' 2>&1)]"
           echo "  disabled   = [$(printf '%s' "$PAY" | jq -r '.disabled // empty' 2>&1)]"
 
+          # The runner blocks a drive-letter path and allows a POSIX-form one. Both
+          # gated sections (symlink, abs-path) start from os.path.isabs(p), and on
+          # Windows a single leading slash is drive-RELATIVE, not absolute. If isabs
+          # is False for '/etc/hosts' then both sections are skipped and the guard
+          # allows it — which matches every observation. Settle it here; it cannot
+          # be checked from macOS, where posixpath answers instead.
+          echo "--- isabs, the gate both blocking sections start from ---"
+          python3 - <<'PYEOF'
+          import os, sys, ntpath
+          print('  python        =', sys.version.split()[0])
+          for cand in ('/etc/hosts', 'C:/Users/x/f', '/c/Users/x/f', '\\\\etc\\\\hosts'):
+              print(f'    isabs({cand!r:22}) = {os.path.isabs(cand)}   ntpath={ntpath.isabs(cand)}')
+          PYEOF
+
           echo "--- what the refusal comparisons actually see ---"
           SC_PROJ="$W/free" python3 - <<'PYEOF'
           import os

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Safety hooks for Claude Code that run **outside Claude's process** — before commands execute, invisible to the model. Zero context-window cost: the rules live in your shell, not in your prompt.
 
-![Version](https://img.shields.io/badge/version-2.26.82-blue) ![License](https://img.shields.io/badge/license-MIT-green) ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey) ![Tests](https://img.shields.io/badge/tests-3540%20passing-brightgreen)
+![Version](https://img.shields.io/badge/version-2.26.82-blue) ![License](https://img.shields.io/badge/license-MIT-green) ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey) ![Tests](https://img.shields.io/badge/tests-3552%20passing-brightgreen)
 
 ![Supercharger hooks denying destructive commands before they run](assets/demo/demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Safety hooks for Claude Code that run **outside Claude's process** — before commands execute, invisible to the model. Zero context-window cost: the rules live in your shell, not in your prompt.
 
-![Version](https://img.shields.io/badge/version-2.26.82-blue) ![License](https://img.shields.io/badge/license-MIT-green) ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey) ![Tests](https://img.shields.io/badge/tests-3565%20passing-brightgreen)
+![Version](https://img.shields.io/badge/version-2.26.82-blue) ![License](https://img.shields.io/badge/license-MIT-green) ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey) ![Tests](https://img.shields.io/badge/tests-3571%20passing-brightgreen)
 
 ![Supercharger hooks denying destructive commands before they run](assets/demo/demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Safety hooks for Claude Code that run **outside Claude's process** — before commands execute, invisible to the model. Zero context-window cost: the rules live in your shell, not in your prompt.
 
-![Version](https://img.shields.io/badge/version-2.26.82-blue) ![License](https://img.shields.io/badge/license-MIT-green) ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey) ![Tests](https://img.shields.io/badge/tests-3552%20passing-brightgreen)
+![Version](https://img.shields.io/badge/version-2.26.82-blue) ![License](https://img.shields.io/badge/license-MIT-green) ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey) ![Tests](https://img.shields.io/badge/tests-3565%20passing-brightgreen)
 
 ![Supercharger hooks denying destructive commands before they run](assets/demo/demo.gif)
 

--- a/hooks/lib-paths.sh
+++ b/hooks/lib-paths.sh
@@ -59,6 +59,19 @@ export PYTHONIOENCODING PYTHONUTF8
 sc_project_key() { # project_dir -> sets SC_PROJECT_KEY
   local p="${1:-$PWD}"
   p="${p//\//-}"
+  # v2.26.83: also fold Windows path separators and the drive colon. Git Bash's
+  # own $PWD is POSIX (/c/Users/...), but the hook PAYLOAD's cwd on Windows is a
+  # native path (C:\Users\...) because Claude Code is a Windows binary — it has
+  # no forward slash to fold, so the key passed through carrying ':' and '\',
+  # both ILLEGAL in an NTFS filename. The scope file then failed to write or
+  # truncated at the colon, so every project on C: collapsed onto one key and
+  # per-project allowPatterns / customPatterns leaked across projects (audit
+  # HIGH #13, closed on POSIX, still open here). Found by running the suite on
+  # windows-latest for the first time.
+  # No-op on POSIX: real paths there contain neither character, so existing keys
+  # are byte-identical and no installed scope file is orphaned.
+  p="${p//\\/-}"
+  p="${p//:/-}"
   p="${p#-}"
   # Cap for filename limits (255 bytes typical). A collision needs two projects
   # sharing a 100-char path suffix, and degrades to the old shared-file

--- a/hooks/path-guard.sh
+++ b/hooks/path-guard.sh
@@ -217,7 +217,26 @@ def _extra_roots(proj_real):
         os.environ.get('EXTRA_ROOTS', ''),
         os.environ.get('CC_DIRS', ''),
     ) if s)
-    _dbg('roots-raw', raw=raw)
+    # The MSYS installation root, or '' anywhere else. Resolved from the shell's own
+    # location so it does not hardcode "C:/Program Files/Git": bash lives at
+    # <root>/usr/bin/bash, so two levels up is the root. Empty off Windows, which
+    # makes every use of it below a no-op there.
+    _msys_root = ''
+    if os.environ.get('MSYSTEM'):
+        try:
+            import shutil
+            _sh = shutil.which('bash') or ''
+            # Only derive from the MSYS layout <root>/usr/bin/bash. Without this
+            # check the two-levels-up rule silently yields '/' anywhere bash lives
+            # in /bin — which is every POSIX system, and would put a bogus value in
+            # a security comparison the moment MSYSTEM appeared in the environment.
+            _norm = _sh.replace('\\', '/').lower()
+            if _norm.endswith('/usr/bin/bash') or _norm.endswith('/usr/bin/bash.exe'):
+                _msys_root = os.path.realpath(
+                    os.path.join(os.path.dirname(_sh), os.pardir, os.pardir))
+        except Exception:
+            _msys_root = ''
+    _dbg('roots-raw', raw=raw, msys_root=_msys_root)
     if raw:
         try:
             home = os.path.realpath(os.path.expanduser('~'))
@@ -243,6 +262,21 @@ def _extra_roots(proj_real):
                  is_home=(bool(home) and rp == home),
                  is_home_ancestor=(bool(home) and home.startswith(rp + os.sep)))
             if rp == os.path.dirname(rp):
+                continue
+            # v2.26.83: on Git Bash, MSYS rewrites a single-path env var in transit,
+            # so a configured root of "/" reaches this loop already turned into the
+            # MSYS installation root. Measured on a windows-latest runner:
+            #     config  additionalRoots: ["/"]
+            #     python  raw='C:/Program Files/Git/'   is_fs_root=False
+            # The check above therefore never fires, the refusal is silently
+            # bypassed, and the project widens to everything under the Git install
+            # — which is how C:/Program Files/Git/etc/hosts read as in-project.
+            #
+            # Refuse the MSYS root by identity rather than by string: it is wherever
+            # bash itself lives (two levels above /usr/bin/bash), so this holds for
+            # any install location and stays inert off Windows, where MSYSTEM is
+            # unset and the value is empty.
+            if _msys_root and (rp == _msys_root or _msys_root.startswith(rp + os.sep)):
                 continue
             if home and (rp == home or home.startswith(rp + os.sep)):
                 continue

--- a/hooks/path-guard.sh
+++ b/hooks/path-guard.sh
@@ -221,17 +221,31 @@ def _extra_roots(proj_real):
     # location so it does not hardcode "C:/Program Files/Git": bash lives at
     # <root>/usr/bin/bash, so two levels up is the root. Empty off Windows, which
     # makes every use of it below a no-op there.
+    # os.name is the only exact discriminator. On Git Bash the interpreter is NATIVE
+    # Windows python, so this is 'nt'; it is 'posix' on macOS and Linux no matter what
+    # MSYSTEM says. Two weaker tests were tried first and both were wrong:
+    #   - MSYSTEM alone: an env var, so anything may set it.
+    #   - the <root>/usr/bin/bash layout: that is where ORDINARY LINUX keeps bash, so
+    #     it derived '/' as the MSYS root and reddened the ubuntu suite. It passed
+    #     locally only because macOS keeps bash in /bin.
+    # Consequence for testing, stated rather than hidden: the positive case cannot be
+    # exercised off Windows. The suite pins that this stays INERT here; the Windows
+    # recon is what verifies it fires there.
     _msys_root = ''
-    if os.environ.get('MSYSTEM'):
+    if os.name == 'nt' and os.environ.get('MSYSTEM'):
         try:
             import shutil
             _sh = shutil.which('bash') or ''
-            # Only derive from the MSYS layout <root>/usr/bin/bash. Without this
-            # check the two-levels-up rule silently yields '/' anywhere bash lives
-            # in /bin — which is every POSIX system, and would put a bogus value in
-            # a security comparison the moment MSYSTEM appeared in the environment.
+            # Require the .exe: on Git Bash this resolves through NATIVE Windows
+            # python, so bash is always bash.exe, and no POSIX bash ever is.
+            #
+            # The first version accepted a bare '/usr/bin/bash' too, which is where
+            # bash lives on ORDINARY LINUX — so the two-levels-up rule derived '/'
+            # as the "MSYS root" and reddened the ubuntu suite. It passed locally
+            # because macOS keeps bash in /bin. A layout is not a platform; the
+            # executable suffix is the part only Windows has.
             _norm = _sh.replace('\\', '/').lower()
-            if _norm.endswith('/usr/bin/bash') or _norm.endswith('/usr/bin/bash.exe'):
+            if _norm.endswith('/usr/bin/bash.exe'):
                 _msys_root = os.path.realpath(
                     os.path.join(os.path.dirname(_sh), os.pardir, os.pardir))
         except Exception:

--- a/hooks/path-guard.sh
+++ b/hooks/path-guard.sh
@@ -12,6 +12,9 @@
 #   {"disableSecurityCategories": ["path-traversal", "symlink", "git-internals",
 #                                   "selfmod", "abs-path", "build-artifacts"]}
 # Disable: SUPERCHARGER_PATH_GUARD=0
+# Debug:   SC_PATHGUARD_DEBUG=1 — trace each gate to stderr (never stdout, which
+#          carries the verdict). Off by default; added after six probes failed to
+#          explain a Windows verdict and tracing the real gates settled it in one.
 
 set -euo pipefail
 HOOKS_DIR="${BASH_SOURCE[0]%/*}"

--- a/hooks/path-guard.sh
+++ b/hooks/path-guard.sh
@@ -214,6 +214,7 @@ def _extra_roots(proj_real):
         os.environ.get('EXTRA_ROOTS', ''),
         os.environ.get('CC_DIRS', ''),
     ) if s)
+    _dbg('roots-raw', raw=raw)
     if raw:
         try:
             home = os.path.realpath(os.path.expanduser('~'))
@@ -235,6 +236,9 @@ def _extra_roots(proj_real):
                 continue
             # Root of the filesystem, $HOME itself, or any ANCESTOR of $HOME
             # (e.g. /Users) would make everything in-project.
+            _dbg('root-cand', entry=entry, rp=rp, is_fs_root=(rp == os.path.dirname(rp)),
+                 is_home=(bool(home) and rp == home),
+                 is_home_ancestor=(bool(home) and home.startswith(rp + os.sep)))
             if rp == os.path.dirname(rp):
                 continue
             if home and (rp == home or home.startswith(rp + os.sep)):

--- a/hooks/path-guard.sh
+++ b/hooks/path-guard.sh
@@ -132,7 +132,26 @@ p = os.environ.get('FILE_PATH', '')
 proj = os.environ.get('PROJECT_DIR', '')
 disabled = set(c.strip() for c in os.environ.get('DISABLED', '').split(',') if c.strip())
 
+# v2.26.83: opt-in trace, inert unless SC_PATHGUARD_DEBUG is set. Added because
+# five separate probes each answered ONE input to this guard and none identified
+# why a POSIX-form absolute path is allowed on Windows while a drive-letter one is
+# blocked. Probing inputs one at a time was not converging; tracing the real code
+# through its gates settles it in a single run. Writes to stderr so it can never be
+# mistaken for a verdict — the verdict is stdout, and an empty stdout means allow.
+_DBG = os.environ.get('SC_PATHGUARD_DEBUG', '') not in ('', '0')
+
+
+def _dbg(where, **kw):
+    if not _DBG:
+        return
+    bits = '  '.join(f'{k}={v!r}' for k, v in kw.items())
+    sys.stderr.write(f'[path-guard:{where}] {bits}\n')
+
+
+_dbg('input', p=p, proj=proj, disabled=sorted(disabled))
+
 if not p:
+    _dbg('exit', why='empty file_path -> allow')
     sys.exit(0)
 
 # v2.23.13: the "project boundary" is the session's cwd, but Claude Code is often
@@ -284,12 +303,16 @@ if 'path-traversal' not in disabled:
 # the lexical path (a symlink was followed) — plain absolute-outside paths keep
 # deferring to abs-path (with its safe-list + memory-store allowance); `..` paths
 # already exited in the path-traversal category above.
+_dbg('3.2-gate', enabled=('symlink' not in disabled), proj_set=bool(proj))
 if 'symlink' not in disabled and proj:
     try:
         proj_real = os.path.realpath(proj)
         cand = p if os.path.isabs(p) else os.path.join(proj_real, p)
         full = os.path.realpath(cand)
         lexical = os.path.normpath(cand)
+        _dbg('3.2', isabs=os.path.isabs(p), cand=cand, full=full, lexical=lexical,
+             differs=(full != lexical), proj_real=proj_real,
+             repo_root=_repo_root(proj_real), within=_within_project(full, proj_real))
         if full != lexical:  # a symlink changed the resolution
             if re.search(r'(^|/)\.git/(hooks|refs|objects|config)(/|$)', full):
                 print('write resolves via a symlink into git internals ('
@@ -301,8 +324,8 @@ if 'symlink' not in disabled and proj:
                       + full[:120] + ') — out-of-project write; '
                       'opt out via disableSecurityCategories: ["symlink"]')
                 sys.exit(0)
-    except Exception:
-        pass
+    except Exception as _e:
+        _dbg('3.2-EXCEPTION', err=repr(_e))
 
 # --- 3.3 Git internals + supercharger hooks ---
 if 'git-internals' not in disabled:
@@ -421,6 +444,8 @@ if 'abs-path' not in disabled and os.path.isabs(p) and proj:
         proj_real = os.path.realpath(proj)
         target_dir = os.path.dirname(p) or '/'
         target_real = os.path.realpath(target_dir)
+        _dbg('3.4-generic', target_dir=target_dir, target_real=target_real,
+             proj_real=proj_real, within=_within_project(target_real, proj_real))
         if not _within_project(target_real, proj_real):
             print('absolute path outside project root: ' + p[:100] + '; opt out via disableSecurityCategories: ["abs-path"]')
             sys.exit(0)

--- a/hooks/project-config.sh
+++ b/hooks/project-config.sh
@@ -152,7 +152,12 @@ if stack_parts:
 # MUST match sc_project_key() in hooks/lib-paths.sh byte for byte, or the writer
 # and the readers disagree and the config silently does nothing.
 def _project_key(pdir):
-    k = (pdir or '/').replace('/', '-')
+    # MUST stay byte-identical to sc_project_key in hooks/lib-paths.sh — the two
+    # channels resolve the same project's scope files and a disagreement means
+    # one writes a file the other never reads.
+    # v2.26.83: '\\' and ':' folded for Windows payload cwds (C:\Users\...), which
+    # carry no '/' to fold and are illegal in an NTFS filename. See lib-paths.sh.
+    k = (pdir or '/').replace('/', '-').replace('\\', '-').replace(':', '-')
     if k.startswith('-'):
         k = k[1:]
     if len(k) > 100:

--- a/hooks/safety.sh
+++ b/hooks/safety.sh
@@ -329,6 +329,57 @@ PYEOF
         if [ -n "$BAD" ]; then
           block "recursive force rm on protected path ($BAD)"
         fi
+
+        # v2.26.83: the python resolver above is INERT ON WINDOWS, and everything it
+        # is the only guard for therefore failed OPEN. Proven on a windows-latest
+        # runner, not inferred — `rm -rf /etc` (both flag orders), `rm /. -rf`, and
+        # deleting the project dir or an ancestor of it were all ALLOWED.
+        #
+        # Cause: every check there realpath()s the token first. On Windows that maps
+        # `/etc` to `D:\etc`, which never equals the POSIX literal in SYS_ROOTS, and
+        # os.sep is a backslash so `r + os.sep` builds the nonsense prefix `/etc\`.
+        # All three checks (cwd-ancestor, system root, home) break the same way.
+        # `rm -rf /` kept blocking via the bash arm above, which is exactly why the
+        # CI smoke test stayed green and hid this for the whole port.
+        #
+        # A TEXT match, gated to Windows. Text is the right layer here: the operator
+        # typed `/etc` whatever the platform, so no path resolution is needed to know
+        # what they meant. The gate makes the macOS/Linux path provably unchanged —
+        # $OSTYPE is never msys/cygwin there, so this block cannot execute.
+        #
+        # Deliberately mirrors SYS_ROOTS rather than inventing a list, and omits
+        # /var for the same reason the python side does (macOS temp dirs).
+        case "$OSTYPE" in
+          msys*|cygwin*|win32*)
+            # System roots, and anything beneath one.
+            if [[ "$args" =~ (^|[[:space:]])\"?/(etc|usr|bin|sbin|lib|lib64|boot|sys|dev|proc|root|System|Library)(/|\"?[[:space:]]|\"?$) ]]; then
+              block "recursive force rm on protected path (Windows text match)"
+            fi
+            # Root spellings the bash arm above does not cover: `/.`, `/..`, `//`.
+            # Their python equivalents all realpath to '/' on POSIX, which is how
+            # they were caught there.
+            if [[ "$args" =~ (^|[[:space:]])\"?/(\.|\.\.|/)+\"?([[:space:]]|$) ]]; then
+              block "recursive force rm on root (Windows text match)"
+            fi
+            # The project dir itself, or any ancestor of it. $PWD is POSIX-form under
+            # Git Bash (/d/a/...), so a plain prefix comparison is exact — no
+            # resolution, and no drive-letter conversion to get wrong.
+            for _tok in $args; do
+              case "$_tok" in
+                -*) continue ;;
+              esac
+              _t="${_tok%/}"; _t="${_t%\"}"; _t="${_t#\"}"
+              [ -z "$_t" ] && continue
+              case "$_t" in
+                /*)
+                  if [ "$PWD" = "$_t" ] || case "$PWD" in "$_t"/*) true ;; *) false ;; esac; then
+                    block "recursive force rm on the project directory or an ancestor (Windows text match)"
+                  fi
+                  ;;
+              esac
+            done
+            ;;
+        esac
       fi
     fi
   done <<< "$SEGMENTS"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -99,8 +99,15 @@ run_one() {
   rm -rf "$home"
 }
 
+# v2.26.83: TEST_GLOB selects a subset of files. Added for the Windows job, which
+# must run a WINDOWS-RELEVANT subset rather than everything: several test files
+# build a PATH with `ln -sf`, and on Git Bash `ln -s` silently COPIES (measured,
+# plan §11.1), so they would copy bash/python3 and report harness breakage as
+# product failure. Default is unchanged, so mac/Linux keep running everything.
+TEST_GLOB="${TEST_GLOB:-test-*.sh}"
+
 running=0
-for test_file in "$SCRIPT_DIR"/test-*.sh; do
+for test_file in "$SCRIPT_DIR"/$TEST_GLOB; do
   [ -f "$test_file" ] || continue
   run_one "$test_file" &
   running=$((running + 1))
@@ -112,7 +119,9 @@ done
 wait
 
 # Replay in glob order so the report is deterministic regardless of finish order.
-for test_file in "$SCRIPT_DIR"/test-*.sh; do
+# Must use the SAME glob as the run loop above, or a subset run replays files it
+# never executed and reports them as empty.
+for test_file in "$SCRIPT_DIR"/$TEST_GLOB; do
   [ -f "$test_file" ] || continue
   test_name=$(basename "$test_file" .sh)
   echo "--- $test_name ---"
@@ -161,6 +170,12 @@ BADGE=$(grep -oE 'tests-[0-9]+%20passing' "$REPO_DIR/README.md" 2>/dev/null | he
 # failure and send the reader after the wrong bug. (It did — a flaky
 # test-install.sh made the badge check cry drift for two releases.)
 TOTAL_RUN=$((TOTAL_PASSED + TOTAL_FAILED))
+# v2.26.83: a SUBSET run must not judge the badge — it counts a fraction of the
+# suite, so it would always report drift and, worse, `BADGE_DRIFT=1` would fail
+# the Windows job for a number that is correct.
+if [ "$TEST_GLOB" != 'test-*.sh' ]; then
+  BADGE=""
+fi
 if [ -n "$BADGE" ] && [ "$BADGE" != "$TOTAL_RUN" ]; then
   echo "WARNING: README tests badge says ${BADGE}, suite has ${TOTAL_RUN}."
   echo "         Bump it to ${TOTAL_RUN} (tools/release.sh does this automatically on release)."

--- a/tests/test-bulk-exfil-guard.sh
+++ b/tests/test-bulk-exfil-guard.sh
@@ -16,7 +16,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { # name command expected

--- a/tests/test-editor-config-guard.sh
+++ b/tests/test-editor-config-guard.sh
@@ -16,7 +16,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { n=$((n+1)); mkin "$TMP/c$n.json" "$2" "$3"; begin_test "$1"; local g; g=$(verdict "$TMP/c$n.json"); [ "$g" = "$4" ] && pass || fail "expected $4 got $g"; }

--- a/tests/test-env-exec-guard.sh
+++ b/tests/test-env-exec-guard.sh
@@ -16,7 +16,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { n=$((n+1)); mkin "$TMP/c$n" "$2" "$n"; begin_test "$1"; local g; g=$(verdict "$TMP/c$n"); [ "$g" = "$3" ] && pass || fail "expected $3 got $g — $2"; }

--- a/tests/test-generated-file-guard.sh
+++ b/tests/test-generated-file-guard.sh
@@ -20,7 +20,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { n=$((n+1)); mkin "$TMP/c$n" "$2" "$3" "$n"; begin_test "$1"; local g; g=$(verdict "$TMP/c$n"); [ "$g" = "$4" ] && pass || fail "expected $4 got $g"; }

--- a/tests/test-git-config-exec-guard.sh
+++ b/tests/test-git-config-exec-guard.sh
@@ -16,7 +16,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { n=$((n+1)); mkin "$TMP/c$n.json" "$2" "$n"; begin_test "$1"; local g; g=$(verdict "$TMP/c$n.json"); [ "$g" = "$3" ] && pass || fail "expected $3 got $g — $2"; }

--- a/tests/test-msys-root-refusal.sh
+++ b/tests/test-msys-root-refusal.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# additionalRoots:["/"] on Git Bash (v2.26.83)
+#
+# MSYS rewrites a single-path env var in transit, and EXTRA_ROOTS travels that
+# channel. Measured on a windows-latest runner:
+#
+#     config   additionalRoots: ["/"]
+#     python   raw='C:/Program Files/Git/'   is_fs_root=False
+#
+# So the filesystem-root refusal (`rp == dirname(rp)`) never fires, the root is
+# accepted, and the project silently widens to everything under the Git install —
+# which is how C:/Program Files/Git/etc/hosts came back as in-project.
+#
+# The refusal now also rejects the MSYS root, derived from the shell's own location
+# rather than a hardcoded "C:/Program Files/Git", so it holds for any install path.
+#
+# Severity, stated precisely because it was overstated once: a user writing "/" does
+# not get the filesystem root — they get the Git install dir. Silent and wrong, not
+# catastrophic.
+REPO_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+CFG=".supercharger"".json"   # split: the local self-mod guard reads the literal
+
+# A fake MSYS tree. The guard keys on MSYSTEM plus the <root>/usr/bin/bash layout,
+# so both are needed to reproduce the platform.
+MROOT=$(mktemp -d)/Git
+mkdir -p "$MROOT/usr/bin" "$MROOT/etc"
+printf '#!/bin/sh\nexec /bin/bash "$@"\n' > "$MROOT/usr/bin/bash"
+chmod +x "$MROOT/usr/bin/bash"
+
+verdict() { # root, extra-env... -> BLOCK|allow
+  local root="$1"; shift
+  local st rc; st=$(mktemp -d); mkdir -p "$st/free" "$st/home"
+  printf '{"additionalRoots":["%s"]}' "$root" > "$st/free/$CFG"
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s/etc/hosts","content":"x"},"cwd":"%s"}' \
+    "$root" "$st/free" \
+    | env HOME="$st/home" SUPERCHARGER_STATE="$st" "$@" \
+      bash "$REPO_DIR/hooks/path-guard.sh" >/dev/null 2>&1
+  rc=$?
+  rm -rf "$st"
+  [ "$rc" -eq 2 ] && printf 'BLOCK' || printf 'allow'
+}
+
+root_of() { # extra-env... -> the msys_root the guard derives
+  local st; st=$(mktemp -d); mkdir -p "$st/free" "$st/home"
+  printf '{"additionalRoots":["%s"]}' "$MROOT" > "$st/free/$CFG"
+  printf '{"tool_name":"Write","tool_input":{"file_path":"%s/etc/x","content":"x"},"cwd":"%s"}' \
+    "$MROOT" "$st/free" \
+    | env HOME="$st/home" SUPERCHARGER_STATE="$st" SC_PATHGUARD_DEBUG=1 "$@" \
+      bash "$REPO_DIR/hooks/path-guard.sh" 2>&1 >/dev/null \
+    | grep -oE "msys_root='[^']*'" | head -1 | sed "s/msys_root='//; s/'$//"
+  rm -rf "$st"
+}
+
+echo "=== MSYS root refusal ==="
+
+begin_test "the MSYS root is refused as a project root"
+# The bug in its own terms: before the fix this root was accepted, making every
+# file under the Git install in-project.
+[ "$(verdict "$MROOT" MSYSTEM=MINGW64 PATH="$MROOT/usr/bin:$PATH")" = "BLOCK" ] \
+  && pass || fail "the MSYS root was accepted — everything under the Git install is in-project"
+
+begin_test "the root is derived from the shell, not a hardcoded install path"
+GOT=$(root_of MSYSTEM=MINGW64 PATH="$MROOT/usr/bin:$PATH")
+[ -n "$GOT" ] && [ "$(cd "$GOT" && pwd -P)" = "$(cd "$MROOT" && pwd -P)" ] \
+  && pass || fail "derived '$GOT', expected '$MROOT'"
+
+begin_test "GATE: nothing is derived without the MSYS layout"
+# MSYSTEM alone must not be enough. bash lives in /bin on every POSIX system, and
+# the two-levels-up rule would otherwise yield '/' — a bogus value in a security
+# comparison. This is the check the first draft of the fix was missing.
+[ -z "$(root_of MSYSTEM=MINGW64)" ] \
+  && pass || fail "derived a root from a POSIX bash: '$(root_of MSYSTEM=MINGW64)'"
+
+begin_test "GATE: nothing is derived when MSYSTEM is unset"
+[ -z "$(root_of)" ] && pass || fail "derived a root off Windows: '$(root_of)'"
+
+begin_test "GATE: an ordinary directory is still a valid root off Windows"
+# The refusal must not leak into macOS/Linux, where this dir is simply a directory.
+[ "$(verdict "$MROOT")" = "allow" ] \
+  && pass || fail "an ordinary root was refused on a non-Windows platform"
+
+begin_test "GATE: the filesystem root is still refused"
+# The original refusal must keep working — this fix adds to it, not replaces it.
+[ "$(verdict "/")" = "allow" ] && fail "'/' was accepted as a root" || pass
+
+rm -rf "$(dirname "$MROOT")"
+report

--- a/tests/test-msys-root-refusal.sh
+++ b/tests/test-msys-root-refusal.sh
@@ -9,21 +9,29 @@
 #
 # So the filesystem-root refusal (`rp == dirname(rp)`) never fires, the root is
 # accepted, and the project silently widens to everything under the Git install —
-# which is how C:/Program Files/Git/etc/hosts came back as in-project.
+# which is how C:/Program Files/Git/etc/hosts came back as in-project. The refusal
+# now also rejects the MSYS root, derived from the shell's own location rather than
+# a hardcoded install path.
 #
-# The refusal now also rejects the MSYS root, derived from the shell's own location
-# rather than a hardcoded "C:/Program Files/Git", so it holds for any install path.
+# WHAT THIS FILE CAN AND CANNOT CHECK, stated plainly. The guard keys on
+# os.name == 'nt', which is true only under native Windows python. So the POSITIVE
+# case — the MSYS root actually being refused — cannot be exercised here at all, and
+# is verified by the Windows recon instead. Everything below pins the half that CAN
+# be checked off Windows: that the new branch stays completely inert.
 #
-# Severity, stated precisely because it was overstated once: a user writing "/" does
-# not get the filesystem root — they get the Git install dir. Silent and wrong, not
-# catastrophic.
+# That distinction is the point rather than a caveat. Two earlier attempts used
+# weaker discriminators that DID run here — MSYSTEM alone, then the
+# <root>/usr/bin/bash layout — and the second passed on macOS while breaking the
+# ubuntu suite, because ordinary Linux keeps bash in exactly that layout. A test
+# that runs everywhere is worthless if the thing it tests is not the thing that
+# ships.
 REPO_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
 
 CFG=".supercharger"".json"   # split: the local self-mod guard reads the literal
 
-# A fake MSYS tree. The guard keys on MSYSTEM plus the <root>/usr/bin/bash layout,
-# so both are needed to reproduce the platform.
+# A directory shaped like an MSYS install, including the bash layout that fooled the
+# second attempt. On this platform it must be treated as an ordinary directory.
 MROOT=$(mktemp -d)/Git
 mkdir -p "$MROOT/usr/bin" "$MROOT/etc"
 printf '#!/bin/sh\nexec /bin/bash "$@"\n' > "$MROOT/usr/bin/bash"
@@ -53,37 +61,35 @@ root_of() { # extra-env... -> the msys_root the guard derives
   rm -rf "$st"
 }
 
-echo "=== MSYS root refusal ==="
+echo "=== MSYS root refusal (inertness off Windows) ==="
 
-begin_test "the MSYS root is refused as a project root"
-# The bug in its own terms: before the fix this root was accepted, making every
-# file under the Git install in-project.
-[ "$(verdict "$MROOT" MSYSTEM=MINGW64 PATH="$MROOT/usr/bin:$PATH")" = "BLOCK" ] \
-  && pass || fail "the MSYS root was accepted — everything under the Git install is in-project"
-
-begin_test "the root is derived from the shell, not a hardcoded install path"
-GOT=$(root_of MSYSTEM=MINGW64 PATH="$MROOT/usr/bin:$PATH")
-[ -n "$GOT" ] && [ "$(cd "$GOT" && pwd -P)" = "$(cd "$MROOT" && pwd -P)" ] \
-  && pass || fail "derived '$GOT', expected '$MROOT'"
-
-begin_test "GATE: nothing is derived without the MSYS layout"
-# MSYSTEM alone must not be enough. bash lives in /bin on every POSIX system, and
-# the two-levels-up rule would otherwise yield '/' — a bogus value in a security
-# comparison. This is the check the first draft of the fix was missing.
+begin_test "GATE: nothing is derived on this platform, even with MSYSTEM set"
+# os.name is 'posix' here, so the branch must not run at all.
 [ -z "$(root_of MSYSTEM=MINGW64)" ] \
-  && pass || fail "derived a root from a POSIX bash: '$(root_of MSYSTEM=MINGW64)'"
+  && pass || fail "derived a root off Windows: '$(root_of MSYSTEM=MINGW64)'"
+
+begin_test "GATE: an MSYS-shaped bash layout does not trigger it either"
+# The exact shape that broke ubuntu: <root>/usr/bin/bash is where Linux keeps bash.
+[ -z "$(root_of MSYSTEM=MINGW64 PATH="$MROOT/usr/bin:$PATH")" ] \
+  && pass || fail "the /usr/bin/bash layout derived a root: '$(root_of MSYSTEM=MINGW64 PATH="$MROOT/usr/bin:$PATH")'"
 
 begin_test "GATE: nothing is derived when MSYSTEM is unset"
-[ -z "$(root_of)" ] && pass || fail "derived a root off Windows: '$(root_of)'"
+[ -z "$(root_of)" ] && pass || fail "derived a root with MSYSTEM unset: '$(root_of)'"
 
-begin_test "GATE: an ordinary directory is still a valid root off Windows"
-# The refusal must not leak into macOS/Linux, where this dir is simply a directory.
-[ "$(verdict "$MROOT")" = "allow" ] \
+begin_test "GATE: an ordinary directory is still a valid project root"
+# The refusal must not leak into macOS/Linux, where this is just a directory.
+[ "$(verdict "$MROOT" MSYSTEM=MINGW64 PATH="$MROOT/usr/bin:$PATH")" = "allow" ] \
   && pass || fail "an ordinary root was refused on a non-Windows platform"
 
 begin_test "GATE: the filesystem root is still refused"
-# The original refusal must keep working — this fix adds to it, not replaces it.
+# The original check must keep working — this fix adds to it, not replaces it.
 [ "$(verdict "/")" = "allow" ] && fail "'/' was accepted as a root" || pass
+
+begin_test "the guard keys on os.name, not on MSYSTEM or a path layout"
+# Pins the discriminator itself, since the two weaker ones each shipped and each
+# was wrong. Source-level because the behaviour it guards cannot run here.
+grep -q "os.name == 'nt' and os.environ.get('MSYSTEM')" "$REPO_DIR/hooks/path-guard.sh" \
+  && pass || fail "the MSYS gate no longer keys on os.name — a weaker test has crept back"
 
 rm -rf "$(dirname "$MROOT")"
 report

--- a/tests/test-orphan-registration.sh
+++ b/tests/test-orphan-registration.sh
@@ -53,6 +53,12 @@ for ev,v in h.items():
 print('\n'.join(sorted(out)))
 PY
 )
+# v2.26.83: strip CR. Windows python's print() writes \r\n in text mode; bash splits
+# on \n, so every name kept a trailing \r and `[ -f hooks/<name>.sh<CR> ]` was false.
+# That produced 130 failures — 28% of ALL Windows suite failures — from one line,
+# and every one of them read as a missing hook rather than as a parsing bug.
+# Stripped once here rather than in each consumer, so it cannot be half-applied.
+REGISTERED="${REGISTERED//$'\r'/}"
 
 for path in "$REPO_DIR"/hooks/*.sh; do
   f=$(basename "$path")

--- a/tests/test-project-key-windows.sh
+++ b/tests/test-project-key-windows.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Per-project scope keys survive Windows-style paths (v2.26.83)
+#
+# Found by running the suite on windows-latest for the first time (Phase 2 item 4
+# of the Windows plan, which had never landed): `.allow-patterns-C` — a filename
+# truncated at the drive colon.
+#
+# Git Bash's own $PWD is POSIX (/c/Users/...), but the hook PAYLOAD's cwd on
+# Windows is a native path (C:\Users\...) because Claude Code is a Windows binary.
+# The key function folded only '/', so a Windows cwd passed through carrying ':'
+# and '\' — both ILLEGAL in an NTFS filename. The scope file then failed to write
+# or truncated at the colon, collapsing every project on C: onto ONE key. That
+# makes per-project allowPatterns and customPatterns leak between projects: a
+# guard deliberately widened in one repo is widened in all of them. Audit HIGH #13
+# was closed for POSIX and was still open here.
+#
+# Two properties: Windows paths produce a legal, DISTINCT key; and POSIX keys are
+# byte-identical to before, so no installed scope file is orphaned.
+REPO_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+# shellcheck source=hooks/lib-paths.sh
+. "$REPO_DIR/hooks/lib-paths.sh"
+
+bkey() { sc_project_key "$1"; printf '%s' "$SC_PROJECT_KEY"; }
+pkey() { PD="$1" python3 -c "
+import os,re,sys
+sys.path.insert(0,'.')
+src=open('$REPO_DIR/hooks/project-config.sh').read()
+m=re.search(r'def _project_key.*?return k or .root.', src, re.S)
+ns={}
+exec(m.group(0).replace('    ','',1).replace('\n    ','\n'), ns) if False else None
+# exec the function as written, dedented by its own indentation
+body=m.group(0)
+exec(body, ns)
+print(ns['_project_key'](os.environ['PD']))
+"; }
+
+echo "=== Project-Key Windows Tests ==="
+
+# --- Windows-style payload cwds ---
+begin_test "a Windows drive path yields a filename-legal key"
+K=$(bkey 'C:\Users\me\project')
+case "$K" in
+  *:*|*\\*) fail "key still contains an NTFS-illegal character: $K" ;;
+  '')       fail "key came out empty" ;;
+  *)        pass ;;
+esac
+
+begin_test "two projects on the same drive get DIFFERENT keys"
+A=$(bkey 'C:\Users\me\alpha'); B=$(bkey 'C:\Users\me\beta')
+[ "$A" != "$B" ] && pass || fail "both projects collapsed onto one key ($A) — configs leak between them"
+
+begin_test "different drives are distinguished"
+A=$(bkey 'C:\work\proj'); B=$(bkey 'D:\work\proj')
+[ "$A" != "$B" ] && pass || fail "drive letter lost: $A"
+
+begin_test "a mixed-separator path is folded"
+K=$(bkey 'C:/Users/me\project')
+case "$K" in *:*|*\\*) fail "mixed separators left illegal chars: $K" ;; *) pass ;; esac
+
+begin_test "the Git Bash POSIX form still works"
+K=$(bkey '/c/Users/me/project')
+[ "$K" = "c-Users-me-project" ] && pass || fail "unexpected key: $K"
+
+# --- POSIX behaviour must be byte-identical (no orphaned scope files) ---
+begin_test "a plain POSIX path is unchanged by the fix"
+[ "$(bkey '/Users/me/repo')" = "Users-me-repo" ] && pass || fail "POSIX key changed: $(bkey '/Users/me/repo')"
+
+begin_test "root still maps to 'root'"
+[ "$(bkey '/')" = "root" ] && pass || fail "root key changed: $(bkey '/')"
+
+begin_test "the >100 char cap still applies"
+LONG="/$(printf 'a%.0s' $(seq 1 200))"
+LK=$(bkey "$LONG")
+[ "${#LK}" -le 100 ] && pass || fail "cap lost — key is ${#LK} chars"
+
+begin_test "the cap still applies to a long WINDOWS path"
+WLONG="C:\\$(printf 'b%.0s' $(seq 1 200))"
+WK=$(bkey "$WLONG")
+[ "${#WK}" -le 100 ] && pass || fail "cap lost on the Windows form — key is ${#WK} chars"
+
+# --- the two implementations must agree ---
+begin_test "bash and python key functions agree on a Windows path"
+B=$(bkey 'C:\Users\me\project'); P=$(pkey 'C:\Users\me\project')
+[ "$B" = "$P" ] && pass || fail "channels disagree — bash='$B' python='$P'"
+
+begin_test "bash and python agree on a POSIX path"
+B=$(bkey '/Users/me/repo'); P=$(pkey '/Users/me/repo')
+[ "$B" = "$P" ] && pass || fail "channels disagree — bash='$B' python='$P'"
+
+begin_test "bash and python agree on root"
+B=$(bkey '/'); P=$(pkey '/')
+[ "$B" = "$P" ] && pass || fail "channels disagree — bash='$B' python='$P'"
+
+report

--- a/tests/test-pth-persistence-guard.sh
+++ b/tests/test-pth-persistence-guard.sh
@@ -17,7 +17,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { n=$((n+1)); mkin "$TMP/c$n" "$2" "$3"; begin_test "$1"; local g; g=$(verdict "$TMP/c$n"); [ "$g" = "$4" ] && pass || fail "expected $4 got $g"; }

--- a/tests/test-test-mask-guard.sh
+++ b/tests/test-test-mask-guard.sh
@@ -16,7 +16,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print('ASK' if s and json.loads(s)['hookSpecificOutput']['permissionDecision']=='ask' else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { n=$((n+1)); mkin "$TMP/c$n.json" "$2" "$n"; begin_test "$1"; local g; g=$(verdict "$TMP/c$n.json"); [ "$g" = "$3" ] && pass || fail "expected $3 got $g — $2"; }

--- a/tests/test-windows-rm-net.sh
+++ b/tests/test-windows-rm-net.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Windows-gated destructive-path net (v2.26.83)
+#
+# safety.sh's python resolver realpath()s every token before comparing it. On
+# Windows that maps `/etc` to `D:\etc`, which never equals the POSIX literal in
+# SYS_ROOTS, and os.sep is a backslash so `r + os.sep` builds the nonsense prefix
+# `/etc\`. All three of its checks — cwd-ancestor, system root, home — break the
+# same way, so everything it is the SOLE guard for failed OPEN.
+#
+# Proven on a windows-latest runner by the report-only suite recon, not inferred:
+#     ALLOWED: rm -rf /etc          (both flag orders)
+#     ALLOWED: rm /. -rf
+#     ALLOWED: rm -rf <project dir>, and an ancestor of it
+# `rm -rf /` kept blocking through the bash arm, which is why the CI smoke test
+# stayed green and hid this for the entire port.
+#
+# The fix is a TEXT match gated to Windows. Text is the right layer: the operator
+# typed `/etc` whatever the platform, so no resolution is needed to know what they
+# meant. The gate makes macOS/Linux provably unchanged — $OSTYPE is never
+# msys/cygwin there, so the block cannot execute.
+REPO_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+# Testing this on macOS needs the python resolver to be INERT, because otherwise it
+# catches these itself and every case passes without the net doing anything — the
+# first version of this check was exactly that ambiguous. The stub reproduces what
+# the resolver does on Windows: runs, matches nothing, prints nothing, exits 0.
+# That is NOT the same as python being absent, which takes a different branch.
+STUBDIR=$(mktemp -d)
+printf '#!/bin/sh\nexit 0\n' > "$STUBDIR/python3"
+chmod +x "$STUBDIR/python3"
+
+probe() { # command, ostype, [cwd] -> BLOCK|allow
+  local cmd="$1" ost="$2" wd="${3:-}" st rc payload
+  st=$(mktemp -d); mkdir -p "$st/scope" "$st/home"
+  payload=$(CMD="$cmd" ST="$st" python3 -c '
+import json, os
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": os.environ["CMD"]},
+                  "cwd": os.environ["ST"]}))')
+  if [ -n "$wd" ]; then
+    printf '%s' "$payload" | (cd "$wd" && env PATH="$STUBDIR:$PATH" HOME="$st/home" \
+      SUPERCHARGER_STATE="$st" OSTYPE="$ost" bash "$REPO_DIR/hooks/safety.sh") >/dev/null 2>&1
+  else
+    printf '%s' "$payload" | env PATH="$STUBDIR:$PATH" HOME="$st/home" \
+      SUPERCHARGER_STATE="$st" OSTYPE="$ost" bash "$REPO_DIR/hooks/safety.sh" >/dev/null 2>&1
+  fi
+  rc=$?
+  rm -rf "$st"
+  [ "$rc" -eq 2 ] && printf 'BLOCK' || printf 'allow'
+}
+
+echo "=== Windows-gated destructive-path net ==="
+
+begin_test "the stub really does silence the python resolver"
+# Guards the guard. If the resolver still fires, every case below passes for free
+# and a fail-open would ship reported as fixed.
+[ "$(probe 'rm -rf /etc' darwin20)" = "allow" ] && pass \
+  || fail "resolver still active under the stub — the cases below prove nothing"
+
+# --- what the runner proved was ALLOWED -------------------------------------
+begin_test "rm -rf /etc blocks on Windows"
+[ "$(probe 'rm -rf /etc' msys)" = "BLOCK" ] && pass || fail "still fails open"
+
+begin_test "rm /etc -rf blocks on Windows (flags last)"
+[ "$(probe 'rm /etc -rf' msys)" = "BLOCK" ] && pass || fail "flag order evades the net"
+
+begin_test "a path UNDER a system root blocks on Windows"
+[ "$(probe 'rm -rf /usr/lib/x' msys)" = "BLOCK" ] && pass || fail "subpath not covered"
+
+begin_test "rm /. -rf blocks on Windows"
+[ "$(probe 'rm /. -rf' msys)" = "BLOCK" ] && pass || fail "root spelling /. evades the net"
+
+begin_test "rm -rf /.. and // block on Windows"
+{ [ "$(probe 'rm -rf /..' msys)" = "BLOCK" ] && [ "$(probe 'rm -rf //' msys)" = "BLOCK" ]; } \
+  && pass || fail "root spellings /.. or // evade the net"
+
+begin_test "cygwin is gated in as well as msys"
+[ "$(probe 'rm -rf /etc' cygwin)" = "BLOCK" ] && pass || fail "cygwin not gated — OSTYPE is cygwin on Git Bash"
+
+begin_test "the project directory itself blocks on Windows"
+WD=$(mktemp -d)
+[ "$(probe "rm -rf $WD" msys "$WD")" = "BLOCK" ] && pass || fail "project-dir wipe still allowed"
+rm -rf "$WD"
+
+begin_test "an ancestor of the project directory blocks on Windows"
+WD=$(mktemp -d); mkdir -p "$WD/sub/dir"
+[ "$(probe "rm -rf $WD" msys "$WD/sub/dir")" = "BLOCK" ] && pass || fail "ancestor wipe still allowed"
+rm -rf "$WD"
+
+# --- the gate must not change macOS/Linux -----------------------------------
+begin_test "GATE: the net is inert on darwin"
+# With the resolver stubbed, a darwin run must behave exactly as it did before this
+# change — i.e. the net contributes nothing. On a real mac the resolver is not
+# stubbed and still blocks these.
+R=""
+for c in 'rm -rf /etc' 'rm /etc -rf' 'rm -rf /usr/lib/x' 'rm /. -rf'; do
+  [ "$(probe "$c" darwin20)" = "BLOCK" ] && R="$R [$c]"
+done
+[ -z "$R" ] && pass || fail "the net fired on darwin — the gate leaks:$R"
+
+begin_test "GATE: the net is inert on linux"
+R=""
+for c in 'rm -rf /etc' 'rm /. -rf'; do
+  [ "$(probe "$c" linux-gnu)" = "BLOCK" ] && R="$R [$c]"
+done
+[ -z "$R" ] && pass || fail "the net fired on linux — the gate leaks:$R"
+
+# --- ordinary work must survive on Windows ----------------------------------
+begin_test "ordinary deletions still allowed on Windows"
+R=""
+for c in 'rm -rf build/' 'rm -rf ./dist' 'rm -rf node_modules' 'rm -rf target'; do
+  [ "$(probe "$c" msys)" = "BLOCK" ] && R="$R [$c]"
+done
+[ -z "$R" ] && pass || fail "false positives on Windows:$R"
+
+begin_test "a temp dir under /var is still allowed on Windows"
+# SYS_ROOTS deliberately omits /var (macOS mktemp -d lives there); the net mirrors
+# that rather than inventing a stricter list.
+[ "$(probe 'rm -rf /var/folders/t5/tmp.XYZ' msys)" = "allow" ] && pass \
+  || fail "net is stricter than SYS_ROOTS — /var should not be protected"
+
+rm -rf "$STUBDIR"
+report

--- a/tests/test-workflow-pwn-guard.sh
+++ b/tests/test-workflow-pwn-guard.sh
@@ -16,7 +16,7 @@ PY
 }
 verdict() {
   SUPERCHARGER_STATE="$(mktemp -d)" bash "$HOOK" < "$1" > "$TMP/o" 2>/dev/null
-  python3 -c "import json;s=open('$TMP/o').read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')"
+  python3 -c "import json,sys;s=open(sys.argv[1]).read().strip();print(json.loads(s)['hookSpecificOutput']['permissionDecision'].upper() if s else 'ALLOW')" "$TMP/o"
 }
 n=0
 check() { n=$((n+1)); mkin "$TMP/c$n.json" "$2" "$3"; begin_test "$1"; local g; g=$(verdict "$TMP/c$n.json"); [ "$g" = "$4" ] && pass || fail "expected $4 got $g"; }


### PR DESCRIPTION
Recon PR — not for merge as-is.

Phase 2 item 4 of `docs/WINDOWS-SUPPORT-PLAN.md` called for the suite to run on `windows-latest` and it never landed. Today 3540 assertions run on ubuntu+macOS and **zero** on Windows, so any Windows-specific logic breakage is invisible.

This PR exists to produce the actual failure list. The suite step is `continue-on-error` so it cannot turn anything red; the curated `TEST_GLOB` subset will follow from the evidence rather than from guessing which files are Windows-safe.

Also adds `TEST_GLOB` to `tests/run.sh` (default unchanged) and stops a subset run from judging the README badge.